### PR TITLE
[Refactor] 페이지 검증 로직 추가

### DIFF
--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter, redirect } from "react-router-dom";
+import { createBrowserRouter } from "react-router-dom";
 import { Layout } from "./components/organisms";
 import {
   ChallengeCreatePage,
@@ -15,65 +15,13 @@ import {
   HomePage,
   ErrorPage,
 } from "./pages";
-import Cookies from "js-cookie";
-import { getAuthCheckAPI } from "./apis/authAPI";
-import useOrganizationStore from "./states/OrganizationStore";
-
-// Token 유효성 검사 Loader
-// (페이지 진입시 Get API 진행하지 않는 페이지만 적용)
-const checkTokenLoader = async () => {
-  const isValid = Cookies.get("access_token_expire");
-
-  if (!isValid) {
-    try {
-      await getAuthCheckAPI(); // redirect작업은 interceptors에서 일괄 처리
-    } catch {}
-  }
-
-  return null;
-};
-
-// 초기에 홈페이지 진입시 토큰 존재 여부에 따라 리다이렉트 진행
-const initialAuthLoader = async () => {
-  try {
-    await getAuthCheckAPI();
-    return redirect("/challenge/dashboard");
-  } catch {
-    return null;
-  }
-};
-
-// 유효한 토큰을 가지고 로그인 페이지에 접근하는 것을 방지
-const loginAuthLoader = () => {
-  const isValid = Cookies.get("access_token_expire");
-
-  if (isValid) {
-    alert("잘못된 접근입니다.");
-    throw new Response("잘못된 접근입니다.", {
-      status: 403,
-      statusText: "Forbidden",
-    });
-  }
-
-  return null;
-};
-
-// 조직이 존재하면서 onBoarding 페이지에 접근하는 것을 방지
-const onBoardingAuthLoader = () => {
-  checkTokenLoader();
-
-  const { organizationId } = useOrganizationStore.getState();
-
-  if (organizationId) {
-    alert("잘못된 접근입니다.");
-    throw new Response("잘못된 접근입니다.", {
-      status: 403,
-      statusText: "Forbidden",
-    });
-  }
-
-  return null;
-};
+import {
+  initialAuthLoader,
+  loginAuthLoader,
+  onBoardingAuthLoader,
+  APIPageAuthLoader,
+  nonAPIPageAuthLoader,
+} from "./utils/loaderUtils";
 
 export const router = createBrowserRouter([
   {
@@ -100,51 +48,56 @@ export const router = createBrowserRouter([
       {
         path: "/challenge/create",
         element: <ChallengeCreatePage />,
-        errorElement: <div>Unknown Error</div>,
-        loader: checkTokenLoader,
+        errorElement: <ErrorPage />,
+        loader: nonAPIPageAuthLoader,
       },
       {
         path: "/challenge/dashboard",
         element: <ChallengeDashboardPage />,
-        errorElement: <div>Unknown Error</div>,
+        errorElement: <ErrorPage />,
+        loader: APIPageAuthLoader,
       },
       {
         path: "/challenge/info",
         element: <ChallengeInfoPage />,
-        errorElement: <div>Unknown Error</div>,
+        errorElement: <ErrorPage />,
+        loader: APIPageAuthLoader,
       },
       {
         path: "/challenge/question",
         element: <ChallengeQuestionPage />,
-        errorElement: <div>Unknown Error</div>,
+        errorElement: <ErrorPage />,
+        loader: APIPageAuthLoader,
       },
       {
         path: "/challenge/custom",
         element: <ChallengeCustomPage />,
-        errorElement: <div>Unknown Error</div>,
-        loader: checkTokenLoader,
+        errorElement: <ErrorPage />,
+        loader: nonAPIPageAuthLoader,
       },
       {
         path: "/participation/info",
         element: <ParticipationInfoPage />,
-        errorElement: <div>Unknown Error</div>,
+        errorElement: <ErrorPage />,
+        loader: APIPageAuthLoader,
       },
       {
         path: "/participation/participate",
         element: <ParticipationParticipatePage />,
-        errorElement: <div>Unknown Error</div>,
+        errorElement: <ErrorPage />,
+        loader: APIPageAuthLoader,
       },
       {
         path: "/organization/edit",
         element: <OrganizationEditPage />,
-        errorElement: <div>Unknown Error</div>,
-        loader: checkTokenLoader,
+        errorElement: <ErrorPage />,
+        loader: nonAPIPageAuthLoader,
       },
       {
         path: "/empty",
         element: <EmptyChallengePage />,
-        errorElement: <div>Unknown Error</div>,
-        loader: checkTokenLoader,
+        errorElement: <ErrorPage />,
+        loader: nonAPIPageAuthLoader,
       },
     ],
   },

--- a/src/utils/loaderUtils.ts
+++ b/src/utils/loaderUtils.ts
@@ -1,0 +1,117 @@
+import { redirect } from "react-router-dom";
+import Cookies from "js-cookie";
+import { getAuthCheckAPI } from "../apis/authAPI";
+import useOrganizationStore from "../states/OrganizationStore";
+import useChallengeStore from "../states/ChallengeStore";
+
+// Token 유효성 검사 Loader
+// (페이지 진입시 Get API 진행하지 않는 페이지만 적용)
+const checkTokenLoader = async () => {
+  const isValid = Cookies.get("access_token_expire");
+  if (!isValid) {
+    try {
+      await getAuthCheckAPI(); // redirect작업은 interceptors에서 일괄 처리
+    } catch {}
+  }
+
+  return null;
+};
+
+// 조직 생성 여부 검사 Loader
+const checkOrganiztionLoader = () => {
+  const { organizationId } = useOrganizationStore.getState();
+
+  if (!organizationId) {
+    alert("조직을 먼저 생성해주세요");
+    return redirect("/onBoarding");
+  }
+
+  return null;
+};
+
+// 챌린지 생성 여부 검사 Loader
+const checkChallengeLoader = () => {
+  const { challengeId } = useChallengeStore.getState();
+
+  if (!challengeId) {
+    alert("챌린지를 먼저 생성해주세요");
+    return redirect("/challenge/create");
+  }
+
+  return null;
+};
+
+// 초기에 홈페이지 진입시 토큰 존재 여부에 따라 리다이렉트 진행
+const initialAuthLoader = async () => {
+  try {
+    await getAuthCheckAPI(); // 실패시 login 페이지로 이동
+    return redirect("/challenge/dashboard"); // 성공시 dashboard 페이지로 이동
+  } catch {
+    return null;
+  }
+};
+
+// 유효한 토큰을 가지고 로그인 페이지에 접근하는 것을 방지
+const loginAuthLoader = () => {
+  const isValid = Cookies.get("access_token_expire");
+
+  // 1. token 유효성 검사
+  if (isValid) {
+    // 2. token 유효할 경우 조직 생성 여부 검사
+    const onBoardingRedirection = checkOrganiztionLoader();
+    if (onBoardingRedirection) return onBoardingRedirection;
+
+    // 3. token이 유효하고 조직도 생성되어있는 경우 403 error 던짐
+    alert("잘못된 접근입니다.");
+    throw new Response("잘못된 접근입니다.", {
+      status: 401,
+      statusText: "Unathorized",
+    });
+  }
+
+  return null;
+};
+
+// 조직이 존재하면서 onBoarding 페이지에 접근하는 것을 방지
+const onBoardingAuthLoader = () => {
+  checkTokenLoader();
+
+  const { organizationId } = useOrganizationStore.getState();
+
+  if (organizationId) {
+    alert("잘못된 접근입니다.");
+    throw new Response("잘못된 접근입니다.", {
+      status: 401,
+      statusText: "Unathorized",
+    });
+  }
+
+  return null;
+};
+
+// Get API가 존재하는 페이지에 대한 검증 로직
+const APIPageAuthLoader = () => {
+  // 1. 조직 존재 여부 검사
+  const onBoardingRedirection = checkOrganiztionLoader();
+  if (onBoardingRedirection) return onBoardingRedirection;
+
+  // 2. 챌린지 존재 여부 검사
+  return checkChallengeLoader();
+};
+
+// Get API가 존재하지 않는 페이지에 대한 검증 로직
+const nonAPIPageAuthLoader = () => {
+  // 1. 토큰 존재 여부 검사
+  checkTokenLoader();
+
+  // 2. 조직 존재 여부 검사
+  return checkOrganiztionLoader();
+};
+
+export {
+  initialAuthLoader,
+  loginAuthLoader,
+  onBoardingAuthLoader,
+  APIPageAuthLoader,
+  nonAPIPageAuthLoader,
+};


### PR DESCRIPTION
> Close #74

## Preview

## Commit
### ✅ refactor: router loader를 사용한 페이지 이동 검증 로직 추가
- [1.Get API 요청이 있는 페이지]
- 조직 존재 여부에 대해 검사해서 존재하지 않는 경우 /onBoarding 페이지로 리다이렉트 진행
- 챌린지 존재 여부에 대해 검사해서 존재하지 않는 경우 /challenge/craete 페이지로 리다이렉트 진행
- 로직 추가 이유: 챌린지가 존재하지 않는 경우 challengeId의 미입력으로 통신에러가 발생할 수 있음
- [2.Get API 요청이 없는 페이지]
- 토큰 존재 여부를 검사한 후 존재하지 않는 경우 /login 페이지로 리다이렉트 진행
- 조직 존재 여부에 대해 검사해서 존재하지 않는 경우 /onBoarding 페이지로 리다이렉트 진행
- 로직 추가 이유: Get API가 없는 경우 토큰의 존재 여부와 조직 생성 여부를 확인할 수 없기 때문에 프론트단에서 전부 검증
- 추가 변경사항
- 잘못된 접근일 시 던지는 에러코드는 권한 인증에서 실패한 경우이기 때문에 403에서 401로 변경
- 로그인 페이지에서 조직 존재 여부 검증 로직 추가


## Comment

- 예시
